### PR TITLE
Add links to WIP webknossos docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,9 @@ theme:
 nav:
   - Welcome: "index.md"
   - Upload data: "upload.md"
+  - Webknossos:
+    - Deployment: https://github.com/lincbrain/webknossos/blob/ak-dev/LINC_DEPLOYMENT.md
+    - Development: https://github.com/lincbrain/webknossos/blob/ak-dev/LINC_DEVELOPMENT.md
   - DANDI Docs: https://www.dandiarchive.org/handbook
   - API:
     - LINC Client: https://lincbrain.readthedocs.io


### PR DESCRIPTION
We will update these links to point to the `main` branch once https://github.com/lincbrain/webknossos/pull/10 is merged.

cc @aaronkanzer 